### PR TITLE
fix: use correct log prefixes

### DIFF
--- a/.changes/unreleased/🐛 Bug Fix-20221026-222227.yaml
+++ b/.changes/unreleased/🐛 Bug Fix-20221026-222227.yaml
@@ -1,0 +1,9 @@
+---
+kind: 🐛 Bug Fix
+body: use correct log prefixes which improves integration with GitHub Actions platform
+time: 2022-10-26T22:22:27.074552+03:00
+custom:
+  azure-boards-workitemid-fixed: ''
+  azure-boards-workitemid-related: ''
+  github-contributor: ''
+  github-link: ''

--- a/.changes/unreleased/🐛 Bug Fix-20221026-222227.yaml
+++ b/.changes/unreleased/🐛 Bug Fix-20221026-222227.yaml
@@ -1,6 +1,6 @@
 ---
 kind: 🐛 Bug Fix
-body: use correct log prefixes which improves integration with GitHub Actions platform
+body: Adjust log prefix used in the GitHub action to improve the integration with actions and error identification.
 time: 2022-10-26T22:22:27.074552+03:00
 custom:
   azure-boards-workitemid-fixed: ''

--- a/dga/dga.go
+++ b/dga/dga.go
@@ -66,15 +66,15 @@ func (cfg *Config) configureLogging() {
 	pterm.Warning = *pterm.Error.WithShowLineNumber().WithLineNumberOffset(1)
 
 	pterm.Error.Prefix = pterm.Prefix{
-		Text:  "::error ",
+		Text:  "::error::",
 		Style: &pterm.Style{},
 	}
 	pterm.Debug.Prefix = pterm.Prefix{
-		Text:  "::debug ",
+		Text:  "::debug::",
 		Style: &pterm.Style{},
 	}
 	pterm.Warning.Prefix = pterm.Prefix{
-		Text:  "::warning ",
+		Text:  "::warning::",
 		Style: &pterm.Style{},
 	}
 	pterm.Success.Printfln("configureLogging() success")
@@ -195,9 +195,8 @@ func Run() error { //nolint:funlen,cyclop // funlen: this could use refactoring 
 		}
 
 		outputKey := item.OutputVariable
-		pterm.Debug.Printfln("%q: Set output %q to value in %q", item.SecretPath, outputKey, item.SecretKey)
 
-		if err := ActionsExportVariable(envFile, outputKey, val); err != nil { // TODO: this needs to be correctly set to use the right output variable.
+		if err := ActionExportVariable(envFile, outputKey, val); err != nil { // TODO: this needs to be correctly set to use the right output variable.
 			pterm.Error.Printfln("%q: unable to export env variable: %v", outputKey, err)
 			return fmt.Errorf("cannot set environment variable")
 		}
@@ -315,7 +314,7 @@ func ActionsOpenEnvFile(cfg *Config) (*os.File, error) {
 	return envFile, nil
 }
 
-func ActionsExportVariable(envFile *os.File, key, val string) error {
+func ActionExportVariable(envFile *os.File, key, val string) error {
 	pterm.Info.Println("actionsExportVariable()")
 	if _, err := envFile.WriteString(fmt.Sprintf("%s=%s\n", strings.ToUpper(key), val)); err != nil {
 		return fmt.Errorf("could not update %s environment file: %w", envFile.Name(), err)

--- a/dga/dga.go
+++ b/dga/dga.go
@@ -33,6 +33,8 @@ type Config struct {
 	RetrieveEnv     string `env:"DSV_RETRIEVE,required"`               // JSON formatted string with data to retrieve from DSV.
 }
 
+// SecretToRetrieve defines JSON format of elements that expected in DSV_RETRIEVE list.
+//nolint:tagliatelle // Here 'camel' casing is used instead of 'kebab'.
 type SecretToRetrieve struct {
 	SecretPath     string `json:"secretPath"`
 	SecretKey      string `json:"secretKey"`


### PR DESCRIPTION
Use correct log prefixes to better communicate with the runner machine.